### PR TITLE
change key.bucket.name to bucket_name

### DIFF
--- a/wal_e/worker/s3/s3_deleter.py
+++ b/wal_e/worker/s3/s3_deleter.py
@@ -14,12 +14,12 @@ class Deleter(_Deleter):
         #
         # In wal-e's use, homogeneity of the bucket retaining the keys
         # is presumed to be always the case.
-        bucket_name = page[0].bucket.name
+        bucket_name = page[0].bucket_name
         for key in page:
             if key.bucket_name != bucket_name:
                 raise exception.UserCritical(
                     msg='submitted keys are not part of the same bucket',
                     detail=('The clashing bucket names are {0} and {1}.'
-                            .format(key.bucket.name, bucket_name)),
+                            .format(key.bucket_name, bucket_name)),
                     hint='This should be reported as a bug.')
             key.delete()


### PR DESCRIPTION
boto2 used to reference bucket names for a key via `key.bucket.name`.
In boto3, this has been changed to `key.bucket_name`.

See http://boto3.readthedocs.org/en/latest/reference/services/s3.html#S3.ObjectSummary.bucket_name

fixes #2
