### PR TITLE
Skip unlinked files when creating tar partitions

### DIFF
--- a/wal_e/tar_partition.py
+++ b/wal_e/tar_partition.py
@@ -385,6 +385,7 @@ def _segmentation_guts(root, file_paths, max_partition_size):
                     logger.debug(
                         msg='tar member additions skipping an unlinked file',
                         detail='Skipping {0}.'.format(et_info.submitted_path))
+                    continue
                 else:
                     raise
 


### PR DESCRIPTION
This pull request is based on the patch applied to the upstream/master.
