### PR TITLE
fix(requirements.txt): Revert "Use google-gax==0.12.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ azure-storage>=0.30.0
 gcloud>=0.11.0
 python-swiftclient>=1.8.0
 python-keystoneclient>=0.4.2
-google-gax==0.12.2


### PR DESCRIPTION
It looks version confusions were fixed by libraries.
So now, my patch merged by #15 causes build errors.

```
pkg_resources.ContextualVersionConflict: (google-gax 0.12.2 (/usr/local/lib/python2.7/dist-packages), Requirement.parse('google-gax==0.12.3'), set(['gax-google-logging-v2', 'gax-google-pubsub-v1']))
```

(full logs at https://travis-ci.org/monami-ya/postgres/builds/146813439 )

I checked the build is done with success if my patch was not applied.
(full logs at https://travis-ci.org/monami-ya/postgres/builds/146813795 )
